### PR TITLE
Fix array validation in parameter

### DIFF
--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -191,7 +191,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
     }
     {{ end }}
   {{ end }}} else {
-    {{ if .IsArray }}{{ if .Child }}{{ if (and (not .Schema.IsInterface) (or .Child.IsAliased .Child.IsComplexObject)) }}for _, {{ .IndexVar }}{{ .ReceiverName }} := range {{ .ReceiverName }}.{{ pascalize .Name }} {
+    {{ if .IsArray }}{{ if .Child }}{{ if (and (not .Schema.IsInterface) (or .Child.IsAliased .Child.IsComplexObject)) }}for _, {{ .IndexVar }}{{ .ReceiverName }} := range {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body {
       if err := {{ .IndexVar }}{{ .ReceiverName }}.Validate(route.Formats); err != nil {
         res = append(res, err)
         break


### PR DESCRIPTION
The template was generating code that checked the members of the array, before actually assigning the array from the body of the request. This should now be validating the members of the array from the body, and then assigning.